### PR TITLE
feat: JWT 인증/인가 구현 및 카카오 소셜 로그인 연동 (#1)

### DIFF
--- a/src/main/java/com/hearo/HearoApplication.java
+++ b/src/main/java/com/hearo/HearoApplication.java
@@ -2,6 +2,7 @@ package com.hearo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class HearoApplication {

--- a/src/main/java/com/hearo/auth/controller/AuthController.java
+++ b/src/main/java/com/hearo/auth/controller/AuthController.java
@@ -1,0 +1,55 @@
+package com.hearo.auth.controller;
+
+import com.hearo.auth.dto.*;
+import com.hearo.auth.service.AuthService;
+import com.hearo.global.response.ApiResponse;
+import com.hearo.global.response.SuccessStatus;
+import com.hearo.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final UserService userService;
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Map<String,Object>>> signup(@Valid @RequestBody SignupReq req) {
+        var u = userService.createLocalUser(req.email(), req.password(), req.nickname());
+        return ApiResponse.success(SuccessStatus.SIGNUP_SUCCESS,
+                Map.of("id", u.getId(), "email", u.getEmail(), "nickname", u.getNickname()));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenRes>> login(@Valid @RequestBody LoginReq req) {
+        var token = authService.loginLocal(req);
+        return ApiResponse.success(SuccessStatus.LOGIN_SUCCESS, token);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<TokenRes>> refresh(@RequestBody Map<String,String> body) {
+        var token = authService.refresh(body.get("refresh"));
+        return ApiResponse.success(SuccessStatus.OK, token);
+    }
+
+    @PostMapping("/logout") // 글로벌 로그아웃(전 기기)
+    public ResponseEntity<ApiResponse<Void>> logoutAll(Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        authService.logoutAll(userId);
+        return ApiResponse.success(SuccessStatus.LOGOUT_SUCCESS);
+    }
+
+    @PostMapping("/logout/session")   // 현재 기기만 로그아웃
+    public ResponseEntity<ApiResponse<Void>> logoutSession(@RequestBody Map<String,String> body) {
+        authService.logoutSession(body.get("refresh"));
+        return ApiResponse.success(SuccessStatus.LOGOUT_SUCCESS);
+    }
+}

--- a/src/main/java/com/hearo/auth/domain/RefreshToken.java
+++ b/src/main/java/com/hearo/auth/domain/RefreshToken.java
@@ -1,0 +1,32 @@
+package com.hearo.auth.domain;
+
+import com.hearo.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RefreshToken extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false) private Long userId;
+    @Column(nullable = false, unique = true, length = 64)
+    private String jti;                               // 토큰 식별자
+    @Column(nullable = false) private int tokenVersion;
+    @Column(nullable = false) private Instant expiresAt;
+
+    @Column(nullable = false) private boolean revoked;
+    private String replacedBy;                        // 회전된 새 jti
+
+    public boolean isExpired() { return Instant.now().isAfter(expiresAt); }
+    public void revoke(String replacedByJti) { this.revoked = true; this.replacedBy = replacedByJti; }
+    public void revokeOnly() { this.revoked = true; }
+}

--- a/src/main/java/com/hearo/auth/dto/LoginReq.java
+++ b/src/main/java/com/hearo/auth/dto/LoginReq.java
@@ -1,0 +1,9 @@
+package com.hearo.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginReq(
+        @Email String email,
+        @NotBlank String password
+) {}

--- a/src/main/java/com/hearo/auth/dto/SignupReq.java
+++ b/src/main/java/com/hearo/auth/dto/SignupReq.java
@@ -1,0 +1,11 @@
+package com.hearo.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignupReq(
+        @Email String email,
+        @Size(min = 8, max = 64) String password,
+        @NotBlank String nickname
+) {}

--- a/src/main/java/com/hearo/auth/dto/TokenRes.java
+++ b/src/main/java/com/hearo/auth/dto/TokenRes.java
@@ -1,0 +1,8 @@
+package com.hearo.auth.dto;
+
+public record TokenRes(
+        String access,
+        String refresh,
+        String tokenType,
+        long   expiresIn
+) {}

--- a/src/main/java/com/hearo/auth/handler/CustomOAuth2UserService.java
+++ b/src/main/java/com/hearo/auth/handler/CustomOAuth2UserService.java
@@ -1,0 +1,36 @@
+package com.hearo.auth.handler;
+
+import com.hearo.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserService userService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest req) {
+        OAuth2User o = super.loadUser(req);
+        Map<String, Object> attrs = o.getAttributes();
+
+        String kakaoId = String.valueOf(attrs.get("id"));
+        Map<String, Object> account = (Map<String, Object>) attrs.get("kakao_account");
+        Map<String, Object> profile = account != null ? (Map<String, Object>) account.get("profile") : null;
+        String email = account != null ? (String) account.get("email") : null;
+        String nickname = profile != null ? (String) profile.getOrDefault("nickname","카카오사용자") : "카카오사용자";
+
+        userService.upsertKakaoUser(kakaoId, email, nickname);
+
+        return new DefaultOAuth2User(List.of(new SimpleGrantedAuthority("ROLE_USER")), attrs, "id");
+    }
+}

--- a/src/main/java/com/hearo/auth/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/hearo/auth/handler/OAuth2FailureHandler.java
@@ -1,0 +1,9 @@
+package com.hearo.auth.handler;
+
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    public OAuth2FailureHandler() { super("/auth/kakao/failure"); }
+}

--- a/src/main/java/com/hearo/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/hearo/auth/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,108 @@
+package com.hearo.auth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hearo.auth.domain.RefreshToken;
+import com.hearo.auth.repository.RefreshTokenRepository;
+import com.hearo.global.jwt.JwtProvider;
+import com.hearo.user.domain.User;
+import com.hearo.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final UserRepository users;
+    private final RefreshTokenRepository refreshTokens;
+    private final JwtProvider jwt;
+    private final ObjectMapper om = new ObjectMapper();
+
+    // 프론트랑 나중에 경로 맞춰야 돼
+    private static final String MOBILE_REDIRECT = "hearo://auth/callback";
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest req, HttpServletResponse res, Authentication auth)
+            throws IOException {
+
+        OAuth2User o = (OAuth2User) auth.getPrincipal();
+        String kakaoId = String.valueOf(o.getAttributes().get("id"));
+        User u = users.findByKakaoId(kakaoId).orElseThrow();
+
+        // refresh 저장 (회전/재사용 탐지용)
+        String jti = UUID.randomUUID().toString();
+        refreshTokens.save(RefreshToken.builder()
+                .userId(u.getId())
+                .jti(jti)
+                .tokenVersion(u.getTokenVersion())
+                .expiresAt(Instant.now().plusSeconds(jwt.refreshTtlSeconds()))
+                .revoked(false)
+                .build());
+
+        String access  = jwt.createAccess(u.getId(), u.getTokenVersion(), List.of("ROLE_USER"));
+        String refresh = jwt.createRefresh(u.getId(), u.getTokenVersion(), jti);
+
+        if (shouldReturnJson(req)) {
+            writeJson(res, access, refresh);
+        } else {
+            String redirect = UriComponentsBuilder.fromUriString(MOBILE_REDIRECT)
+                    .queryParam("access", access)
+                    .queryParam("refresh", refresh)
+                    .build()
+                    .encode()
+                    .toUriString();
+            getRedirectStrategy().sendRedirect(req, res, redirect);
+        }
+    }
+
+    /**
+     * JSON 응답으로 강제 전환하는 조건:
+     * 1) URL 쿼리파라미터: ?debugJson=true
+     * 2) 환경변수: APP_OAUTH2_SUCCESS_RESPONSE=json
+     * 3) JVM 옵션: -Dapp.oauth2.success-response=json
+     * 개발시에는 json 형식으로 응답, 운영시에는 저 위에 있는 경로로 응답 전달할 거
+     */
+    private boolean shouldReturnJson(HttpServletRequest req) {
+        // 1) 쿼리 파라미터
+        String q = req.getParameter("debugJson");
+        if ("true".equalsIgnoreCase(q)) return true;
+
+        // 2) 환경변수
+        String envVal = System.getenv("APP_OAUTH2_SUCCESS_RESPONSE");
+        if ("json".equalsIgnoreCase(envVal)) return true;
+
+        // 3) JVM 시스템 프로퍼티
+        String sysVal = System.getProperty("app.oauth2.success-response");
+        return "json".equalsIgnoreCase(sysVal);
+    }
+
+    private void writeJson(HttpServletResponse res, String access, String refresh) throws IOException {
+        res.setStatus(HttpServletResponse.SC_OK);
+        res.setContentType("application/json;charset=UTF-8");
+        Map<String, Object> body = Map.of(
+                "status", 200,
+                "success", true,
+                "code", "LOGIN_SUCCESS",
+                "message", "소셜 로그인에 성공했습니다.",
+                "data", Map.of(
+                        "access", access,
+                        "refresh", refresh,
+                        "tokenType", "Bearer",
+                        "expiresIn", jwt.accessTtlSeconds()
+                )
+        );
+        om.writeValue(res.getWriter(), body);
+    }
+}

--- a/src/main/java/com/hearo/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/hearo/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.hearo.auth.repository;
+
+import com.hearo.auth.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByJti(String jti);
+}

--- a/src/main/java/com/hearo/auth/service/AuthService.java
+++ b/src/main/java/com/hearo/auth/service/AuthService.java
@@ -1,0 +1,130 @@
+package com.hearo.auth.service;
+
+import com.hearo.auth.domain.RefreshToken;
+import com.hearo.auth.dto.LoginReq;
+import com.hearo.auth.dto.TokenRes;
+import com.hearo.auth.repository.RefreshTokenRepository;
+import com.hearo.global.exception.ApiException;
+import com.hearo.global.jwt.JwtPayload;
+import com.hearo.global.jwt.JwtProvider;
+import com.hearo.global.response.ErrorStatus;
+import com.hearo.user.domain.User;
+import com.hearo.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserRepository users;
+    private final RefreshTokenRepository refreshTokens;
+    private final PasswordEncoder encoder;
+    private final JwtProvider jwt;
+
+    /* ---------- 일반 로그인 ---------- */
+    @Transactional
+    public TokenRes loginLocal(LoginReq req) {
+        User u = users.findByEmail(req.email())
+                .filter(x -> x.getAuthType()== User.AuthType.LOCAL && Boolean.TRUE.equals(x.getEnabled()))
+                .orElseThrow(() -> new ApiException(ErrorStatus.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        if (!encoder.matches(req.password(), u.getPasswordHash()))
+            throw new ApiException(ErrorStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다.");
+
+        return issueTokens(u);
+    }
+
+    /* ---------- 리프레시: 회전 + 재사용 탐지 ---------- */
+    @Transactional
+    public TokenRes refresh(String refreshToken) {
+        JwtPayload p = jwt.verify(refreshToken);
+        if (!"REFRESH".equals(p.typ()))
+            throw new ApiException(ErrorStatus.REFRESH_TOKEN_INVALID);
+
+        User u = users.findById(p.userId())
+                .orElseThrow(() -> new ApiException(ErrorStatus.USER_NOT_FOUND));
+
+        if (p.ver() == null || p.ver() != u.getTokenVersion())
+            throw new ApiException(ErrorStatus.REFRESH_TOKEN_INVALID, "버전 불일치");
+
+        if (p.jti() == null)
+            throw new ApiException(ErrorStatus.REFRESH_TOKEN_INVALID, "JTI 누락");
+
+        RefreshToken token = refreshTokens.findByJti(p.jti())
+                .orElseThrow(() -> new ApiException(ErrorStatus.REFRESH_TOKEN_INVALID));
+
+        // 재사용/만료/회수 감지
+        if (token.isExpired() || token.isRevoked()) {
+            u.bumpTokenVersion();              // 전 세션 무효화
+            users.save(u);
+            throw new ApiException(ErrorStatus.REFRESH_TOKEN_INVALID, "재사용 감지 - 전체 로그아웃");
+        }
+
+        // 회전: 기존 토큰 revoke + 새 jti 발급
+        String newJti = UUID.randomUUID().toString();
+        token.revoke(newJti);
+        refreshTokens.save(token);
+
+        RefreshToken newRt = RefreshToken.builder()
+                .userId(u.getId())
+                .jti(newJti)
+                .tokenVersion(u.getTokenVersion())
+                .expiresAt(Instant.now().plusSeconds(jwt.refreshTtlSeconds()))
+                .revoked(false)
+                .build();
+        refreshTokens.save(newRt);
+
+        String access  = jwt.createAccess(u.getId(), u.getTokenVersion(), List.of("ROLE_USER"));
+        String refresh = jwt.createRefresh(u.getId(), u.getTokenVersion(), newJti);
+        return new TokenRes(access, refresh, "Bearer", jwt.accessTtlSeconds());
+    }
+
+    /* ---------- 글로벌 로그아웃(전 세션 무효화) ---------- */
+    @Transactional
+    public void logoutAll(Long userId) {
+        User u = users.findById(userId).orElseThrow(() -> new ApiException(ErrorStatus.USER_NOT_FOUND));
+        u.bumpTokenVersion(); // 전 세션 만료
+        users.save(u);
+        // (선택) userId 기준 refresh 일괄 revoke 처리 가능
+    }
+
+    /* ---------- 현재 기기 로그아웃(리프레시 jti만 취소) ---------- */
+    @Transactional
+    public void logoutSession(String refreshToken) {
+        JwtPayload p = jwt.verify(refreshToken);
+        if (!"REFRESH".equals(p.typ()) || p.jti() == null)
+            throw new ApiException(ErrorStatus.REFRESH_TOKEN_INVALID);
+
+        RefreshToken t = refreshTokens.findByJti(p.jti())
+                .orElseThrow(() -> new ApiException(ErrorStatus.REFRESH_TOKEN_INVALID));
+
+        t.revokeOnly();
+        refreshTokens.save(t);
+    }
+
+    /* ---------- 내부: 토큰 발급 + refresh 저장 ---------- */
+    private TokenRes issueTokens(User u) {
+        String jti = UUID.randomUUID().toString();
+
+        RefreshToken rt = RefreshToken.builder()
+                .userId(u.getId())
+                .jti(jti)
+                .tokenVersion(u.getTokenVersion())
+                .expiresAt(Instant.now().plusSeconds(jwt.refreshTtlSeconds()))
+                .revoked(false)
+                .build();
+        refreshTokens.save(rt);
+
+        String access  = jwt.createAccess(u.getId(), u.getTokenVersion(), List.of("ROLE_USER"));
+        String refresh = jwt.createRefresh(u.getId(), u.getTokenVersion(), jti);
+        return new TokenRes(access, refresh, "Bearer", jwt.accessTtlSeconds());
+    }
+}

--- a/src/main/java/com/hearo/global/config/PasswordConfig.java
+++ b/src/main/java/com/hearo/global/config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.hearo.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/hearo/global/config/SecurityConfig.java
+++ b/src/main/java/com/hearo/global/config/SecurityConfig.java
@@ -1,30 +1,47 @@
 package com.hearo.global.config;
 
+import com.hearo.auth.handler.CustomOAuth2UserService;
+import com.hearo.auth.handler.OAuth2FailureHandler;
+import com.hearo.auth.handler.OAuth2SuccessHandler;
+import com.hearo.global.jwt.JwtAuthFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
 
-    @Bean
-    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-            .csrf(csrf -> csrf.disable()) // API 서버 기본값
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers(
-                        "/actuator/health",
-                        "/auth/**",
-                        "/login/**",
-                        "/oauth2/**"
-                ).permitAll()
-                .anyRequest().authenticated()
-            )
-            .oauth2Login(Customizer.withDefaults()) // /login/oauth2/code/kakao
-            .logout(logout -> logout.logoutUrl("/auth/logout"));
+    private final JwtAuthFilter jwtAuthFilter;
+    private final CustomOAuth2UserService oAuth2UserService;
+    private final OAuth2SuccessHandler successHandler;
+    private final OAuth2FailureHandler failureHandler;
 
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/**", "/oauth2/**", "/login/**", "/actuator/health"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth -> oauth
+                        .userInfoEndpoint(u -> u.userService(oAuth2UserService))
+                        .successHandler(successHandler)
+                        .failureHandler(failureHandler)
+                );
+
+        http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
+
 }

--- a/src/main/java/com/hearo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hearo/global/exception/GlobalExceptionHandler.java
@@ -35,7 +35,7 @@ public class GlobalExceptionHandler {
         if (ex instanceof MethodArgumentNotValidException manv) {
             var errors = manv.getBindingResult().getFieldErrors();
             if (!errors.isEmpty()) {
-                var fe = errors.get(0); // Java 17 호환 (getFirst() 대신 get(0))
+                var fe = errors.get(0);
                 message = fe.getField() + ": " + fe.getDefaultMessage();
             }
         } else if (ex instanceof BindException be) {

--- a/src/main/java/com/hearo/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/hearo/global/jwt/JwtAuthFilter.java
@@ -1,0 +1,50 @@
+package com.hearo.global.jwt;
+
+import com.hearo.user.domain.User;
+import com.hearo.user.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwt;
+    private final UserRepository users;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+            throws ServletException, IOException {
+
+        String h = req.getHeader(HttpHeaders.AUTHORIZATION);
+        if (h != null && h.startsWith("Bearer ")) {
+            String token = h.substring(7);
+            try {
+                JwtPayload p = jwt.verify(token);
+                if ("ACCESS".equals(p.typ())) {
+                    User u = users.findById(p.userId()).orElse(null);
+                    if (u != null && Boolean.TRUE.equals(u.getEnabled())
+                            && u.getTokenVersion() == p.ver()) {
+                        var auth = new UsernamePasswordAuthenticationToken(
+                                u.getId(), null,
+                                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+                        SecurityContextHolder.getContext().setAuthentication(auth);
+                    }
+                }
+            } catch (Exception ignore) {}
+        }
+        chain.doFilter(req, res);
+    }
+}

--- a/src/main/java/com/hearo/global/jwt/JwtPayload.java
+++ b/src/main/java/com/hearo/global/jwt/JwtPayload.java
@@ -1,0 +1,3 @@
+package com.hearo.global.jwt;
+
+public record JwtPayload(Long userId, String typ, Integer ver, String jti) {}

--- a/src/main/java/com/hearo/global/jwt/JwtProvider.java
+++ b/src/main/java/com/hearo/global/jwt/JwtProvider.java
@@ -1,0 +1,63 @@
+package com.hearo.global.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+@Component
+public class JwtProvider {
+
+    @Value("${security.jwt.secret}") private String secretB64;
+    @Value("${security.jwt.access-token-validity}")   private long accessTtl;
+    @Value("${security.jwt.refresh-token-validity}") private long refreshTtl;
+
+    private Key key() {
+        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretB64));
+    }
+
+    public String createAccess(Long userId, int tokenVer, List<String> roles) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim("typ", "ACCESS")
+                .claim("ver", tokenVer)
+                .claim("roles", roles)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plusSeconds(accessTtl)))
+                .signWith(key(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefresh(Long userId, int tokenVer, String jti) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim("typ", "REFRESH")
+                .claim("ver", tokenVer)
+                .claim("jti", jti)
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plusSeconds(refreshTtl)))
+                .signWith(key(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public JwtPayload verify(String token) {
+        var jws = Jwts.parserBuilder().setSigningKey(key()).build().parseClaimsJws(token);
+        var c = jws.getBody();
+        Long uid = Long.valueOf(c.getSubject());
+        String typ = (String) c.get("typ");
+        Integer ver = (Integer) c.get("ver");
+        String jti = (String) c.get("jti");
+        return new JwtPayload(uid, typ, ver, jti);
+    }
+
+    public long accessTtlSeconds()  { return accessTtl; }
+    public long refreshTtlSeconds() { return refreshTtl; }
+}

--- a/src/main/java/com/hearo/global/props/HearoAuthProps.java
+++ b/src/main/java/com/hearo/global/props/HearoAuthProps.java
@@ -1,0 +1,13 @@
+package com.hearo.global.props;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "hearo.auth")
+public class HearoAuthProps {
+    /** 추후 이 api는 프론트와 상의 후 변경예정 hearo://auth/callback */
+    private String successRedirect = "hearo://auth/callback";
+    public String getSuccessRedirect() { return successRedirect; }
+    public void setSuccessRedirect(String s) { this.successRedirect = s; }
+}

--- a/src/main/java/com/hearo/user/controller/UserController.java
+++ b/src/main/java/com/hearo/user/controller/UserController.java
@@ -1,0 +1,25 @@
+package com.hearo.user.controller;
+
+import com.hearo.user.domain.User;
+import com.hearo.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserService users;
+
+    @GetMapping("/me") // 테스트용 api
+    public Map<String, Object> me(Authentication auth) {
+        Long userId = (Long) auth.getPrincipal();
+        User u = users.getById(userId);
+        return Map.of("id", u.getId(), "email", u.getEmail(), "nickname", u.getNickname(),
+                      "authType", u.getAuthType().name());
+    }
+}

--- a/src/main/java/com/hearo/user/domain/User.java
+++ b/src/main/java/com/hearo/user/domain/User.java
@@ -1,0 +1,43 @@
+package com.hearo.user.domain;
+
+import com.hearo.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class User extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true) private String email;    // LOCAL
+    private String passwordHash;                    // LOCAL
+    @Column(unique = true) private String kakaoId;  // KAKAO
+
+    @Column(nullable = false) private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private AuthType authType;
+
+    @Column(nullable = false) private Boolean enabled;
+
+    @Column(nullable = false) private int tokenVersion = 0;  // 🔸
+
+    public enum AuthType { LOCAL, KAKAO }
+
+    public static User createLocal(String email, String encodedPassword, String nickname) {
+        return new User(null, email, encodedPassword, null, nickname, AuthType.LOCAL, true, 0);
+    }
+    public static User createKakao(String kakaoId, String emailOrNull, String nickname) {
+        return new User(null, emailOrNull, null, kakaoId, nickname, AuthType.KAKAO, true, 0);
+    }
+
+    public void changeNickname(String newNickname) { this.nickname = newNickname; }
+    public void disable() { this.enabled = false; }
+    public void bumpTokenVersion() { this.tokenVersion += 1; } // 글로벌 로그아웃
+}

--- a/src/main/java/com/hearo/user/repository/UserRepository.java
+++ b/src/main/java/com/hearo/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.hearo.user.repository;
+
+import com.hearo.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
+    Optional<User> findByKakaoId(String kakaoId);
+}

--- a/src/main/java/com/hearo/user/service/UserService.java
+++ b/src/main/java/com/hearo/user/service/UserService.java
@@ -1,0 +1,37 @@
+package com.hearo.user.service;
+
+import com.hearo.global.exception.ApiException;
+import com.hearo.global.response.ErrorStatus;
+import com.hearo.user.domain.User;
+import com.hearo.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository users;
+    private final PasswordEncoder encoder;
+
+    @Transactional
+    public User createLocalUser(String email, String rawPassword, String nickname) {
+        if (users.existsByEmail(email)) {
+            throw new ApiException(ErrorStatus.DUPLICATE_RESOURCE, "이미 사용 중인 이메일입니다.");
+        }
+        return users.save(User.createLocal(email, encoder.encode(rawPassword), nickname));
+    }
+
+    @Transactional
+    public User upsertKakaoUser(String kakaoId, String emailOrNull, String nickname) {
+        return users.findByKakaoId(kakaoId).orElseGet(() ->
+                users.save(User.createKakao(kakaoId, emailOrNull, nickname)));
+    }
+
+    public User getById(Long id) {
+        return users.findById(id).orElseThrow(() -> new ApiException(ErrorStatus.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
- JWT 기반 인증 로직 구현  
  - Access / Refresh 토큰 발급 및 검증  
  - Refresh 토큰 회전 및 재사용 감지 로직 추가  
  - 글로벌 로그아웃(전 기기 무효화), 세션 로그아웃(단일 기기 무효화) API 구현  
- 카카오 OAuth2 소셜 로그인 연동  
  - Kakao Developers 설정 기반 OAuth2 인증 처리  
  - 개발/테스트 모드에서 JSON 응답 분기 처리 옵션 추가  
- 글로벌 예외 처리 및 응답 규격 통일 (`ApiResponse`, `ErrorStatus`, `SuccessStatus`)  
- `/api/v1/users/me` 보호 API 추가 및 JWT 인증 헤더 테스트 완료  

## ➕ 이슈 링크
* Closes #1 

## 🧪 테스트 방법(API 명세서 참고)
- **회원가입 (Local)**
- **로그인 (Local)**
- **토큰 갱신**
- **로그아웃(현재기기만/전체기기모두)**
- **소셜 로그인 (Kakao)**
  - 로그인 후 JSON 응답 확인 가능  
- **보호 API 호출**
  - 로그인한 유저 정보 반환 확인  

## ✅ 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)  
- [x] 주요 기능 수동 테스트 완료 (회원가입/로그인/리프레시/로그아웃/OAuth2)  
- [x] 예외/실패 응답 형식 일관성 확인  
- [x] 카카오 OAuth2 로그인 정상 동작 확인  
- [x] `/api/v1/users/me` 보호 API 접근 제어 동작 확인  

## 📸 스크린샷 (선택)

