### PR TITLE
Feat/#4 signlanguage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,12 @@ dependencies {
 	// xml -> json
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
+	// api 호출 재시도/서킷/레이트리밋
+	implementation "io.github.resilience4j:resilience4j-spring-boot3:2.2.0"
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,8 @@ dependencies {
 
 	// api 호출 재시도/서킷/레이트리밋
 	implementation "io.github.resilience4j:resilience4j-spring-boot3:2.2.0"
+
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,14 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// WebClient + Reactor Netty
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'io.projectreactor.netty:reactor-netty'
+
+	// xml -> json
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hearo/global/config/SecurityConfig.java
+++ b/src/main/java/com/hearo/global/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/v1/auth/**", "/oauth2/**", "/login/**", "/actuator/health"
+                                "/api/v1/auth/**", "/oauth2/**", "/login/**", "/actuator/health",
+                                "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/hearo/global/response/ErrorStatus.java
+++ b/src/main/java/com/hearo/global/response/ErrorStatus.java
@@ -32,7 +32,11 @@ public enum ErrorStatus {
     CONTACT_ALREADY_EXISTS(HttpStatus.CONFLICT, "CONTACT_ALREADY_EXISTS", "이미 관계가 존재합니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
+
+    /* 429 TOO_MANY_REQUESTS */
+    EXTERNAL_QUOTA(HttpStatus.TOO_MANY_REQUESTS, "EXTERNAL_QUOTA",
+            "외부 KCISA API 일일 호출 제한을 초과했습니다. DB 조회 엔드포인트를 이용해주세요.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/hearo/signlanguage/client/SignApiClient.java
+++ b/src/main/java/com/hearo/signlanguage/client/SignApiClient.java
@@ -1,0 +1,62 @@
+package com.hearo.signlanguage.client;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.hearo.signlanguage.client.dto.SignRawResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class SignApiClient {
+
+    private final WebClient signApiWebClient;
+
+    @Value("${sign.api.service-key}")
+    private String serviceKey;
+
+    public SignRawResponse fetch(String keyword, int pageNo, int numOfRows) {
+        String kw = (keyword == null) ? "" : keyword;
+
+        String xml = signApiWebClient.get()
+                .uri(uri -> uri.path("/API_CNV_054/request")
+                        .queryParam("serviceKey", serviceKey)
+                        .queryParam("numOfRows", numOfRows)
+                        .queryParam("pageNo", pageNo)
+                        .queryParam("keyword", kw)
+                        .queryParam("collectionDb", "")
+                        .build())
+                .accept(MediaType.APPLICATION_XML)  // XML로 받기
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        if (xml == null || xml.isBlank()) {
+            throw new IllegalStateException("KCISA API 빈 응답");
+        }
+
+        try {
+            XmlMapper xmlMapper = new XmlMapper();
+            xmlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            JsonNode xmlTree = xmlMapper.readTree(xml.getBytes(StandardCharsets.UTF_8)); // 루트 <response>
+
+            ObjectMapper jsonMapper = new ObjectMapper()
+                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+            ObjectNode wrapped = jsonMapper.createObjectNode();
+            wrapped.set("response", xmlTree);
+
+            return jsonMapper.treeToValue(wrapped, SignRawResponse.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("KCISA XML 파싱 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/hearo/signlanguage/client/SignApiClient.java
+++ b/src/main/java/com/hearo/signlanguage/client/SignApiClient.java
@@ -3,7 +3,6 @@ package com.hearo.signlanguage.client;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.hearo.signlanguage.client.dto.SignRawResponse;
 import lombok.RequiredArgsConstructor;
@@ -46,12 +45,12 @@ public class SignApiClient {
         try {
             XmlMapper xmlMapper = new XmlMapper();
             xmlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-            JsonNode xmlTree = xmlMapper.readTree(xml.getBytes(StandardCharsets.UTF_8)); // 루트 <response>
+            JsonNode xmlTree = xmlMapper.readTree(xml.getBytes(StandardCharsets.UTF_8));
 
             ObjectMapper jsonMapper = new ObjectMapper()
                     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-            ObjectNode wrapped = jsonMapper.createObjectNode();
+            var wrapped = jsonMapper.createObjectNode();
             wrapped.set("response", xmlTree);
 
             return jsonMapper.treeToValue(wrapped, SignRawResponse.class);

--- a/src/main/java/com/hearo/signlanguage/client/dto/SignRawResponse.java
+++ b/src/main/java/com/hearo/signlanguage/client/dto/SignRawResponse.java
@@ -1,0 +1,42 @@
+package com.hearo.signlanguage.client.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class SignRawResponse {
+    private Response response;
+
+    @Data public static class Response {
+        private Header header;
+        private Body body;
+    }
+    @Data public static class Header {
+        private String resultCode; // "0000"
+        private String resultMsg;  // "OK"
+    }
+    @Data public static class Body {
+        private Items items;
+        private String numOfRows;
+        private String pageNo;
+        private String totalCount;
+    }
+    @Data public static class Items {
+        private List<Item> item;
+    }
+    @Data public static class Item {
+        private String title;
+        private String alternativeTitle;
+        private String description;
+        private String subDescription;   // mp4 URL
+        private String localId;
+        private String viewCount;
+        private String url;              // 외부 상세
+        private String imageObject;      // 썸네일
+        private String period;
+        private String signDescription;
+        private String signImages;       // csv
+        private String collectionDb;
+        private String categoryType;
+    }
+}

--- a/src/main/java/com/hearo/signlanguage/config/WebClientConfig.java
+++ b/src/main/java/com/hearo/signlanguage/config/WebClientConfig.java
@@ -1,0 +1,40 @@
+package com.hearo.signlanguage.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${spring.webclient.connect-timeout-ms}")
+    private int connectTimeoutMs;
+
+    @Value("${spring.webclient.read-timeout-ms}")
+    private int readTimeoutMs;
+
+    @Bean
+    public WebClient signApiWebClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMs)
+                .doOnConnected(c -> c.addHandler(new ReadTimeoutHandler(readTimeoutMs, TimeUnit.MILLISECONDS)));
+
+        return WebClient.builder()
+                .baseUrl("https://api.kcisa.kr")
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(cfg -> cfg.defaultCodecs().maxInMemorySize(4 * 1024 * 1024))
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/hearo/signlanguage/config/WebClientConfig.java
+++ b/src/main/java/com/hearo/signlanguage/config/WebClientConfig.java
@@ -2,6 +2,7 @@ package com.hearo.signlanguage.config;
 
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,11 +11,14 @@ import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
+@Slf4j
 public class WebClientConfig {
 
     @Value("${spring.webclient.connect-timeout-ms}")
@@ -27,11 +31,22 @@ public class WebClientConfig {
     public WebClient signApiWebClient() {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, connectTimeoutMs)
+                .responseTimeout(Duration.ofMillis(readTimeoutMs + 1000))
                 .doOnConnected(c -> c.addHandler(new ReadTimeoutHandler(readTimeoutMs, TimeUnit.MILLISECONDS)));
 
         return WebClient.builder()
                 .baseUrl("https://api.kcisa.kr")
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_XML_VALUE)
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .filter((req, next) -> {
+                    long start = System.currentTimeMillis();
+                    log.info("[REQ] {} {}", req.method(), req.url());
+                    return next.exchange(req)
+                            .doOnNext(res -> {
+                                long took = System.currentTimeMillis() - start;
+                                log.info("[RES] status={} url={} took={}ms", res.statusCode(), req.url(), took);
+                            });
+                })
                 .exchangeStrategies(ExchangeStrategies.builder()
                         .codecs(cfg -> cfg.defaultCodecs().maxInMemorySize(4 * 1024 * 1024))
                         .build())

--- a/src/main/java/com/hearo/signlanguage/controller/SignController.java
+++ b/src/main/java/com/hearo/signlanguage/controller/SignController.java
@@ -1,0 +1,78 @@
+package com.hearo.signlanguage.controller;
+
+import com.hearo.global.response.ApiResponse;
+import com.hearo.global.response.SuccessStatus;
+import com.hearo.signlanguage.domain.SignEntry;
+import com.hearo.signlanguage.dto.IngestResultDto;
+import com.hearo.signlanguage.dto.SignPageDto;
+import com.hearo.signlanguage.service.SignService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/signs")
+@RequiredArgsConstructor
+public class SignController {
+
+    private final SignService service;
+
+    // 외부 API 그대로 조회
+    @GetMapping("/external")
+    public ResponseEntity<ApiResponse<SignPageDto>> externalList(
+            @RequestParam(name = "pageNo", required = false) Integer pageNo,
+            @RequestParam(name = "numOfRows", required = false) Integer numOfRows,
+            @RequestParam(name = "page", required = false) Integer legacyPage,
+            @RequestParam(name = "size", required = false) Integer legacySize
+    ) {
+        int p = (pageNo != null) ? pageNo : (legacyPage != null ? legacyPage : 1);
+        int s = (numOfRows != null) ? numOfRows : (legacySize != null ? legacySize : 10);
+
+        var data = service.externalList(p, s);
+        return ApiResponse.success(SuccessStatus.FETCHED, data);
+    }
+
+    // 외부 API 키워드 검색
+    @GetMapping("/external/search")
+    public ResponseEntity<ApiResponse<SignPageDto>> externalSearch(
+            @RequestParam String keyword,
+            @RequestParam(name = "pageNo", required = false) Integer pageNo,
+            @RequestParam(name = "numOfRows", required = false) Integer numOfRows,
+            @RequestParam(name = "page", required = false) Integer legacyPage,
+            @RequestParam(name = "size", required = false) Integer legacySize
+    ) {
+        int p = (pageNo != null) ? pageNo : (legacyPage != null ? legacyPage : 1);
+        int s = (numOfRows != null) ? numOfRows : (legacySize != null ? legacySize : 10);
+
+        var data = service.externalSearch(keyword, p, s);
+        return ApiResponse.success(SuccessStatus.FETCHED, data);
+    }
+
+    // DB 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<SignEntry>>> listFromDb(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        var data = service.listFromDb(page, size);
+        return ApiResponse.success(SuccessStatus.FETCHED, data);
+    }
+
+    // DB 검색
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<Page<SignEntry>>> searchFromDb(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        var data = service.searchFromDb(keyword, page, size);
+        return ApiResponse.success(SuccessStatus.FETCHED, data);
+    }
+
+    // 모든 수어 DB upsert
+    @PostMapping("/ingest/all")
+    public ResponseEntity<ApiResponse<IngestResultDto>> ingestAll(
+            @RequestParam(defaultValue = "500") int size) {
+        var res = service.ingestAll(size);
+        return ApiResponse.success(SuccessStatus.OK, res);
+    }
+}

--- a/src/main/java/com/hearo/signlanguage/controller/SignController.java
+++ b/src/main/java/com/hearo/signlanguage/controller/SignController.java
@@ -75,4 +75,13 @@ public class SignController {
         var res = service.ingestAll(size);
         return ApiResponse.success(SuccessStatus.OK, res);
     }
+
+    // 모든 수어 DB 병렬로 insert
+    @PostMapping("/ingest/all/parallel")
+    public ResponseEntity<ApiResponse<IngestResultDto>> ingestAllParallel(
+            @RequestParam(defaultValue = "500") int size) {
+        var res = service.ingestAllParallel(size);
+        return ApiResponse.success(SuccessStatus.OK, res);
+    }
+
 }

--- a/src/main/java/com/hearo/signlanguage/domain/SignEntry.java
+++ b/src/main/java/com/hearo/signlanguage/domain/SignEntry.java
@@ -1,0 +1,72 @@
+package com.hearo.signlanguage.domain;
+
+import com.hearo.signlanguage.dto.SignItemDto;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "sign_entries", indexes = {
+        @Index(name = "idx_sign_local_id", columnList = "localId", unique = true),
+        @Index(name = "idx_sign_title", columnList = "title")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class SignEntry {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 64, unique = true)
+    private String localId;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(length = 1000)
+    private String videoUrl;
+
+    @Column(length = 1000)
+    private String thumbnailUrl;
+
+    @Lob @Column(columnDefinition = "TEXT")
+    private String signDescription;
+
+    @Lob @Column(columnDefinition = "TEXT")
+    private String imagesCsv;
+
+    @Column(length = 1000)
+    private String sourceUrl;
+
+    @Column(length = 100)
+    private String collectionDb;
+
+    @Column(length = 100)
+    private String categoryType;
+
+    private Integer viewCount;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @PrePersist void onCreate() { this.createdAt = LocalDateTime.now(); this.updatedAt = this.createdAt; }
+    @PreUpdate  void onUpdate() { this.updatedAt = LocalDateTime.now(); }
+
+    public void updateFrom(SignItemDto dto) {
+        this.title = dto.getTitle();
+        this.videoUrl = dto.getVideoUrl();
+        this.thumbnailUrl = dto.getThumbnailUrl();
+        this.signDescription = dto.getSignDescription();
+        this.imagesCsv = String.join(",", safeList(dto.getImages()));
+        this.sourceUrl = dto.getSourceUrl();
+        this.collectionDb = dto.getCollectionDb();
+        this.categoryType = dto.getCategoryType();
+        this.viewCount = dto.getViewCount();
+    }
+
+    private static List<String> safeList(List<String> in) { return (in == null) ? List.of() : in; }
+}

--- a/src/main/java/com/hearo/signlanguage/domain/SignEntry.java
+++ b/src/main/java/com/hearo/signlanguage/domain/SignEntry.java
@@ -1,5 +1,6 @@
 package com.hearo.signlanguage.domain;
 
+import com.hearo.global.entity.BaseTimeEntity;
 import com.hearo.signlanguage.dto.SignItemDto;
 import jakarta.persistence.*;
 import lombok.*;
@@ -16,7 +17,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class SignEntry {
+public class SignEntry extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -49,12 +50,6 @@ public class SignEntry {
     private String categoryType;
 
     private Integer viewCount;
-
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-
-    @PrePersist void onCreate() { this.createdAt = LocalDateTime.now(); this.updatedAt = this.createdAt; }
-    @PreUpdate  void onUpdate() { this.updatedAt = LocalDateTime.now(); }
 
     public void updateFrom(SignItemDto dto) {
         this.title = dto.getTitle();

--- a/src/main/java/com/hearo/signlanguage/dto/IngestResultDto.java
+++ b/src/main/java/com/hearo/signlanguage/dto/IngestResultDto.java
@@ -1,0 +1,14 @@
+package com.hearo.signlanguage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class IngestResultDto {
+    private int totalCount;
+    private int totalFetched;
+    private int inserted;
+    private int updated;
+    private int pageSize;
+}

--- a/src/main/java/com/hearo/signlanguage/dto/SignItemDto.java
+++ b/src/main/java/com/hearo/signlanguage/dto/SignItemDto.java
@@ -1,0 +1,20 @@
+package com.hearo.signlanguage.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import java.util.List;
+
+@Data
+@Builder
+public class SignItemDto {
+    private String title;
+    private String localId;
+    private String videoUrl;
+    private String thumbnailUrl;
+    private String signDescription;
+    private List<String> images;
+    private String sourceUrl;
+    private String collectionDb;
+    private String categoryType;
+    private Integer viewCount;
+}

--- a/src/main/java/com/hearo/signlanguage/dto/SignPageDto.java
+++ b/src/main/java/com/hearo/signlanguage/dto/SignPageDto.java
@@ -1,0 +1,14 @@
+package com.hearo.signlanguage.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import java.util.List;
+
+@Data
+@Builder
+public class SignPageDto {
+    private List<SignItemDto> items;
+    private int pageNo;
+    private int numOfRows;
+    private int totalCount;
+}

--- a/src/main/java/com/hearo/signlanguage/repository/SignEntryBulkRepository.java
+++ b/src/main/java/com/hearo/signlanguage/repository/SignEntryBulkRepository.java
@@ -1,0 +1,74 @@
+package com.hearo.signlanguage.repository;
+
+import com.hearo.signlanguage.dto.SignItemDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SignEntryBulkRepository {
+
+    private final JdbcTemplate jdbc;
+
+    private static final String UPSERT_SQL = """
+        INSERT INTO sign_entries
+          (local_id, title, video_url, thumbnail_url, sign_description, images_csv,
+           source_url, collection_db, category_type, view_count, created_at, modified_at)
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+        ON DUPLICATE KEY UPDATE
+          title = VALUES(title),
+          video_url = VALUES(video_url),
+          thumbnail_url = VALUES(thumbnail_url),
+          sign_description = VALUES(sign_description),
+          images_csv = VALUES(images_csv),
+          source_url = VALUES(source_url),
+          collection_db = VALUES(collection_db),
+          category_type = VALUES(category_type),
+          view_count = VALUES(view_count),
+          modified_at = NOW()
+        """;
+
+    public int[] upsertBatch(List<SignItemDto> items) {
+        if (items == null || items.isEmpty()) return new int[0];
+
+        return jdbc.batchUpdate(UPSERT_SQL, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                SignItemDto it = items.get(i);
+
+                ps.setString(1,  it.getLocalId());
+                ps.setString(2,  it.getTitle());
+                ps.setString(3,  it.getVideoUrl());
+                ps.setString(4,  it.getThumbnailUrl());
+                ps.setString(5,  it.getSignDescription());
+
+                String imagesCsv = (it.getImages() == null || it.getImages().isEmpty())
+                        ? "" : String.join(",", it.getImages());
+                ps.setString(6,  imagesCsv);
+
+                ps.setString(7,  it.getSourceUrl());
+                ps.setString(8,  it.getCollectionDb());
+                ps.setString(9,  it.getCategoryType());
+
+                if (it.getViewCount() == null) {
+                    ps.setNull(10, Types.INTEGER);
+                } else {
+                    ps.setInt(10, it.getViewCount());
+                }
+            }
+
+            @Override
+            public int getBatchSize() {
+                return items.size();
+            }
+        });
+    }
+}

--- a/src/main/java/com/hearo/signlanguage/repository/SignEntryRepository.java
+++ b/src/main/java/com/hearo/signlanguage/repository/SignEntryRepository.java
@@ -1,0 +1,15 @@
+package com.hearo.signlanguage.repository;
+
+import com.hearo.signlanguage.domain.SignEntry;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SignEntryRepository extends JpaRepository<SignEntry, Long> {
+
+    Optional<SignEntry> findByLocalId(String localId);
+
+    Page<SignEntry> findByTitleContaining(String keyword, Pageable pageable);
+}

--- a/src/main/java/com/hearo/signlanguage/repository/SignEntryRepository.java
+++ b/src/main/java/com/hearo/signlanguage/repository/SignEntryRepository.java
@@ -4,12 +4,25 @@ import com.hearo.signlanguage.domain.SignEntry;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.util.Optional;
+import java.util.*;
 
 public interface SignEntryRepository extends JpaRepository<SignEntry, Long> {
 
     Optional<SignEntry> findByLocalId(String localId);
 
     Page<SignEntry> findByTitleContaining(String keyword, Pageable pageable);
+
+    @Query("select s from SignEntry s where s.localId in :localIds")
+    List<SignEntry> findAllByLocalIdIn(@Param("localIds") List<String> localIds);
+
+    default Map<String, SignEntry> findAllByIdOrLocalId(List<String> localIds) {
+        if (localIds == null || localIds.isEmpty()) return Map.of();
+        var list = findAllByLocalIdIn(localIds);
+        var map = new HashMap<String, SignEntry>(list.size() * 2);
+        for (var s : list) map.put(s.getLocalId(), s);
+        return map;
+    }
 }

--- a/src/main/java/com/hearo/signlanguage/service/SignService.java
+++ b/src/main/java/com/hearo/signlanguage/service/SignService.java
@@ -1,0 +1,170 @@
+package com.hearo.signlanguage.service;
+
+import com.hearo.signlanguage.client.SignApiClient;
+import com.hearo.signlanguage.client.dto.SignRawResponse;
+import com.hearo.signlanguage.domain.SignEntry;
+import com.hearo.signlanguage.dto.IngestResultDto;
+import com.hearo.signlanguage.dto.SignItemDto;
+import com.hearo.signlanguage.dto.SignPageDto;
+import com.hearo.signlanguage.repository.SignEntryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SignService {
+
+    private final SignApiClient client;
+    private final SignEntryRepository repo;
+
+    public SignPageDto externalList(int pageNo, int numOfRows) {
+        SignRawResponse raw = client.fetch(null, pageNo, numOfRows);
+        return toPageDto(raw);
+    }
+
+    public SignPageDto externalSearch(String keyword, int pageNo, int numOfRows) {
+        SignRawResponse raw = client.fetch(keyword, pageNo, numOfRows);
+        return toPageDto(raw);
+    }
+
+    public Page<SignEntry> listFromDb(int page, int size) {
+        Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, Sort.by("id").descending());
+        return repo.findAll(pageable);
+    }
+
+    public Page<SignEntry> searchFromDb(String keyword, int page, int size) {
+        Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, Sort.by("id").descending());
+        return repo.findByTitleContaining(keyword, pageable);
+    }
+
+    @Transactional
+    public IngestResultDto ingestAll(int pageSize) {
+        int pageNo = 1;
+        int totalCount = Integer.MAX_VALUE;
+        int totalFetched = 0, inserted = 0, updated = 0;
+
+        while (true) {
+            SignPageDto page = fetchPage(pageNo, pageSize);
+            if (pageNo == 1) totalCount = page.getTotalCount();
+            if (page.getItems().isEmpty()) break;
+
+            for (SignItemDto dto : page.getItems()) {
+                Optional<SignEntry> opt = repo.findByLocalId(dto.getLocalId());
+                if (opt.isEmpty()) {
+                    repo.save(SignEntry.builder()
+                            .localId(dto.getLocalId())
+                            .title(dto.getTitle())
+                            .videoUrl(dto.getVideoUrl())
+                            .thumbnailUrl(dto.getThumbnailUrl())
+                            .signDescription(dto.getSignDescription())
+                            .imagesCsv(String.join(",", dto.getImages()))
+                            .sourceUrl(dto.getSourceUrl())
+                            .collectionDb(dto.getCollectionDb())
+                            .categoryType(dto.getCategoryType())
+                            .viewCount(dto.getViewCount())
+                            .build());
+                    inserted++;
+                } else {
+                    opt.get().updateFrom(dto);
+                    updated++;
+                }
+            }
+
+            totalFetched += page.getItems().size();
+            if (totalFetched >= totalCount) break;
+            pageNo++;
+        }
+
+        return new IngestResultDto(totalCount, totalFetched, inserted, updated, pageSize);
+    }
+
+    // ===== 내부 헬퍼 =====
+    private SignPageDto fetchPage(int pageNo, int pageSize) {
+        SignRawResponse raw = client.fetch(null, pageNo, pageSize);
+        if (raw == null || raw.getResponse() == null || raw.getResponse().getHeader() == null) {
+            throw new IllegalStateException("외부 API 응답 파싱 실패");
+        }
+        var header = raw.getResponse().getHeader();
+        if (!"0000".equals(header.getResultCode())) {
+            String msg = (header.getResultMsg() != null) ? header.getResultMsg() : "외부 API 오류";
+            throw new IllegalStateException("KCISA API 오류: " + msg);
+        }
+        var body = raw.getResponse().getBody();
+
+        List<SignRawResponse.Item> items =
+                (body != null && body.getItems() != null && body.getItems().getItem() != null)
+                        ? body.getItems().getItem() : List.of();
+
+        List<SignItemDto> list = items.stream().map(this::mapToItemDto).toList();
+
+        String pageNoStr     = (body != null) ? body.getPageNo()     : null;
+        String numOfRowsStr  = (body != null) ? body.getNumOfRows()  : null;
+        String totalCountStr = (body != null) ? body.getTotalCount() : null;
+
+        return SignPageDto.builder()
+                .items(list)
+                .pageNo(parseIntDefault(pageNoStr, 1))
+                .numOfRows(parseIntDefault(numOfRowsStr, list.size()))
+                .totalCount(parseIntDefault(totalCountStr, list.size()))
+                .build();
+    }
+
+    private SignPageDto toPageDto(SignRawResponse raw) {
+        var body = raw.getResponse().getBody();
+        var itemsRaw = (body != null && body.getItems() != null)
+                ? body.getItems().getItem()
+                : List.<SignRawResponse.Item>of();
+
+        List<SignItemDto> list = itemsRaw.stream()
+                .map(this::mapToItemDto)
+                .toList();
+
+        int pageNo     = parseIntDefault(body != null ? body.getPageNo() : null, 1);
+        int totalCount = parseIntDefault(body != null ? body.getTotalCount() : null, list.size());
+
+        return SignPageDto.builder()
+                .items(list)
+                .pageNo(pageNo)
+                .numOfRows(list.size())  // 실제 개수
+                .totalCount(totalCount)
+                .build();
+    }
+
+    private SignItemDto mapToItemDto(SignRawResponse.Item i) {
+        return SignItemDto.builder()
+                .title(nvl(i.getTitle()))
+                .localId(nvl(i.getLocalId()))
+                .videoUrl(nvl(i.getSubDescription()))
+                .thumbnailUrl(nvl(i.getImageObject()))
+                .signDescription(nvl(i.getSignDescription()))
+                .images(splitCsv(i.getSignImages()))
+                .sourceUrl(nvl(i.getUrl()))
+                .collectionDb(nvl(i.getCollectionDb()))
+                .categoryType(nvl(i.getCategoryType()))
+                .viewCount(parseIntOrNull(i.getViewCount()))
+                .build();
+    }
+
+    private static String nvl(String s) { return (s == null) ? "" : s; }
+    private static int parseIntDefault(String s, int def) {
+        try { return (s == null) ? def : Integer.parseInt(s); }
+        catch (NumberFormatException e) { return def; }
+    }
+    private static Integer parseIntOrNull(String s) {
+        try { return (s == null) ? null : Integer.parseInt(s); }
+        catch (NumberFormatException e) { return null; }
+    }
+    private static List<String> splitCsv(String s) {
+        if (s == null || s.isBlank()) return List.of();
+        return Arrays.stream(s.split(","))
+                .map(String::trim)
+                .filter(x -> !x.isBlank())
+                .toList();
+    }
+}

--- a/src/main/java/com/hearo/user/domain/User.java
+++ b/src/main/java/com/hearo/user/domain/User.java
@@ -26,7 +26,7 @@ public class User extends BaseTimeEntity {
 
     @Column(nullable = false) private Boolean enabled;
 
-    @Column(nullable = false) private int tokenVersion = 0;  // 🔸
+    @Column(nullable = false) private int tokenVersion = 0;
 
     public enum AuthType { LOCAL, KAKAO }
 


### PR DESCRIPTION
## 🔎 작업 내용
- **수어 데이터 적재/조회/검색 기능 구현**
  - 외부 KCISA API 연동 (목록/검색)
  - DB 적재 및 조회/검색 API 구현 (페이지네이션, 키워드 검색)
- **데이터 적재 로직 개선**
  - 중복 데이터는 Upsert 처리 (신규만 추가/변경 반영)
  - 순차/병렬 모드 지원, 429 발생 시 중단 처리
- **스케줄러 추가**
  - 매일 자정 자동 적재 → 신규 데이터만 반영
- **안정성/성능 개선**
  - 네트워크 오류/타임아웃 재시도
  - 429(쿼터 초과) 감지 및 에러 응답 통일 (`ErrorStatus.EXTERNAL_QUOTA`)

## ➕ 이슈 링크
* Closes #4 

## 🧪 테스트 방법 (노션 API 명세서 참고)
- DB 수동 적재
- DB 병렬 적재
- DB 수어 데이터 전체 조회
- DB 에서 키워드 검색
- 외부 API 직접 호출

## ✅ 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)  
- [x] 적재/조회/검색 기능 정상 동작 확인  
- [x] 중복 데이터 upsert 확인  
- [x] 429/에러 응답 처리 확인  
- [x] 스케줄러 정상 등록 확인  

## 📸 스크린샷
<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/801bb0ce-bbb2-4c09-b0ed-01f8a0ea3e4a" />
