### PR TITLE
 [FEAT] 수어사전 API 2차 구현 (#4)

### DIFF
--- a/src/main/java/com/hearo/signlanguage/domain/SignFavorite.java
+++ b/src/main/java/com/hearo/signlanguage/domain/SignFavorite.java
@@ -1,0 +1,37 @@
+package com.hearo.signlanguage.domain;
+
+import com.hearo.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "sign_favorites",
+        uniqueConstraints = @UniqueConstraint(name = "uk_sign_fav_user_sign", columnNames = {"user_id", "sign_entry_id"}),
+        indexes = {
+                @Index(name = "idx_sign_fav_user", columnList = "user_id"),
+                @Index(name = "idx_sign_fav_sign", columnList = "sign_entry_id")
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class SignFavorite extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "sign_entry_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_sign_fav_sign_entry"))
+    private SignEntry signEntry;
+
+    public static SignFavorite of(Long userId, SignEntry entry) {
+        return SignFavorite.builder()
+                .userId(userId)
+                .signEntry(entry)
+                .build();
+    }
+}

--- a/src/main/java/com/hearo/signlanguage/dto/SignDetailDto.java
+++ b/src/main/java/com/hearo/signlanguage/dto/SignDetailDto.java
@@ -1,0 +1,28 @@
+package com.hearo.signlanguage.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class SignDetailDto {
+    private Long id;
+    private String localId;
+    private String title;
+    private String videoUrl;
+    private String thumbnailUrl;
+    private String signDescription;
+    private List<String> images;
+    private String sourceUrl;
+    private String collectionDb;
+    private String categoryType;
+    private Integer viewCount;
+
+    private boolean favorite;      // 현재 사용자 기준 즐겨찾기 여부
+    private long favoriteCount;    // 전체 즐겨찾기 수
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/hearo/signlanguage/dto/SignFavoriteItemDto.java
+++ b/src/main/java/com/hearo/signlanguage/dto/SignFavoriteItemDto.java
@@ -1,0 +1,25 @@
+package com.hearo.signlanguage.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class SignFavoriteItemDto {
+    private Long id;               // sign entry id
+    private String localId;
+    private String title;
+    private String videoUrl;
+    private String thumbnailUrl;
+    private String signDescription;
+    private List<String> images;   // imagesCsv → List
+    private String sourceUrl;
+    private String collectionDb;
+    private String categoryType;
+    private Integer viewCount;
+
+    private LocalDateTime favoritedAt; // 내가 찜한 시각
+}

--- a/src/main/java/com/hearo/signlanguage/dto/SignFavoriteRow.java
+++ b/src/main/java/com/hearo/signlanguage/dto/SignFavoriteRow.java
@@ -1,0 +1,23 @@
+package com.hearo.signlanguage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class SignFavoriteRow {
+    public Long id;
+    public String localId;
+    public String title;
+    public String videoUrl;
+    public String thumbnailUrl;
+    public String signDescription;
+    public String imagesCsv;      // 나중에 List로 변환
+    public String sourceUrl;
+    public String collectionDb;
+    public String categoryType;
+    public Integer viewCount;
+    public LocalDateTime favoritedAt;
+}

--- a/src/main/java/com/hearo/signlanguage/repository/SignFavoriteRepository.java
+++ b/src/main/java/com/hearo/signlanguage/repository/SignFavoriteRepository.java
@@ -1,0 +1,31 @@
+package com.hearo.signlanguage.repository;
+
+import com.hearo.signlanguage.domain.SignFavorite;
+import com.hearo.signlanguage.dto.SignFavoriteRow;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface SignFavoriteRepository extends JpaRepository<SignFavorite, Long> {
+
+    boolean existsByUserIdAndSignEntryId(Long userId, Long signEntryId);
+
+    long countBySignEntryId(Long signEntryId);
+
+    void deleteByUserIdAndSignEntryId(Long userId, Long signEntryId);
+
+    // 마이페이지 목록: 내가 찜한 수어 + 찜한 시각 (최신순)
+    @Query("""
+      select new com.hearo.signlanguage.dto.SignFavoriteRow(
+         s.id, s.localId, s.title, s.videoUrl, s.thumbnailUrl, s.signDescription,
+         s.imagesCsv, s.sourceUrl, s.collectionDb, s.categoryType, s.viewCount,
+         f.createdAt
+      )
+      from com.hearo.signlanguage.domain.SignFavorite f
+      join f.signEntry s
+      where f.userId = :userId
+      order by f.createdAt desc
+    """)
+    Page<SignFavoriteRow> findFavoriteRows(Long userId, Pageable pageable);
+}


### PR DESCRIPTION
## 🔎 작업 내용(수어 사전 API 2차 구현)
- **수어 상세조회 및 즐겨찾기 기능 추가**
  - `/api/v1/signs/{id}` : 수어 상세조회 API 추가  
    → 즐겨찾기 여부(`favorite`), 전체 찜 수(`favoriteCount`) 포함  
  - `/api/v1/signs/{id}/favorite` : 즐겨찾기 추가(POST) / 해제(DELETE) API 추가  
  - `/api/v1/signs/favorites` : 마이페이지용 즐겨찾기 목록 조회 API 추가  
    → 최신순(`favoritedAt DESC`) 자동 정렬, 페이지네이션 지원

---

## ➕ 이슈 링크
* Closes #4 

---

## 🧪 테스트 방법 (노션 API 명세서 참고)
- 즐겨찾기 추가
-  즐겨찾기 해제
- 내 즐겨찾기 목록 조회(자동 최신순 정렬)
- 수어 상세보기 확인

---

## ✅ 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)  
- [x] 즐겨찾기 추가/삭제 기능 정상 동작 확인  
- [x] 마이페이지 즐겨찾기 목록 정상 조회 및 최신순 정렬 확인  
- [x] 상세조회 시 찜 상태/카운트 정확히 반영 확인  
- [x] 기존 조회/적재/검색 기능 정상 작동 확인 

---

## 📸 스크린샷
