### PR TITLE
[FIX] 로그인 로직 수정

### DIFF
--- a/src/main/java/com/hearo/global/config/SecurityConfig.java
+++ b/src/main/java/com/hearo/global/config/SecurityConfig.java
@@ -4,15 +4,20 @@ import com.hearo.auth.handler.CustomOAuth2UserService;
 import com.hearo.auth.handler.OAuth2FailureHandler;
 import com.hearo.auth.handler.OAuth2SuccessHandler;
 import com.hearo.global.jwt.JwtAuthFilter;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -23,16 +28,47 @@ public class SecurityConfig {
     private final OAuth2SuccessHandler successHandler;
     private final OAuth2FailureHandler failureHandler;
 
+    /** 1) API 체인: /api/** 전용 (JWT만, 리다이렉트 금지) */
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Order(1)
+    SecurityFilterChain apiChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/api/**")
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsSource()))
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .oauth2Login(oauth -> oauth.disable()) // ★ API에서는 OAuth2 리다이렉트 금지
+                .exceptionHandling(e -> e
+                        .authenticationEntryPoint((req, res, ex) -> {
+                            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            res.setContentType("application/json;charset=UTF-8");
+                            res.getWriter().write("{\"error\":\"unauthorized\"}");
+                        })
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/v1/auth/**",            // 일반 회원가입/로그인/리프레시 등은 공개
+                                "/actuator/health",
+                                "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    /** 2) Web 체인: 나머지 경로 (브라우저용 카카오 OAuth2 유지) */
+    @Bean
+    @Order(2)
+    SecurityFilterChain webChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(
-                                "/api/v1/auth/**", "/oauth2/**", "/login/**", "/actuator/health",
-                                "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"
-                        ).permitAll()
+                        .requestMatchers("/", "/login/**", "/oauth2/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth -> oauth
@@ -40,9 +76,20 @@ public class SecurityConfig {
                         .successHandler(successHandler)
                         .failureHandler(failureHandler)
                 );
-
-        http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 
+    /** CORS (Postman/웹 프론트에서 호출 시 편의) */
+    @Bean
+    CorsConfigurationSource corsSource() {
+        CorsConfiguration c = new CorsConfiguration();
+        c.setAllowedOrigins(List.of("*"));            // 필요 시 도메인으로 제한
+        c.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
+        c.setAllowedHeaders(List.of("*"));
+        c.setExposedHeaders(List.of("Authorization","Location"));
+        c.setAllowCredentials(false);
+        UrlBasedCorsConfigurationSource src = new UrlBasedCorsConfigurationSource();
+        src.registerCorsConfiguration("/**", c);
+        return src;
+    }
 }


### PR DESCRIPTION
## 🔎 작업 내용
- 서버에서 로그인 시도 시 무조건 카카오 간편로그인으로만 응답 줌
- 수정해서 일반 회원가입 / 간편로그인 나눔
## ➕ 이슈 링크
* Closes #

## 🧪 테스트 방법
-

## ✅ 체크리스트
- [ ] 빌드 성공 (`./gradlew clean build`)
- [ ] 주요 기능 수동 테스트 완료
- [ ] 예외/실패 응답 형식 일관성 확인

## 📸 스크린샷 (선택)
-
